### PR TITLE
Fix QDateEditEx's minimumSizeHint so the clear button doesn't hide the year

### DIFF
--- a/test/dateedittest.cpp
+++ b/test/dateedittest.cpp
@@ -1,27 +1,22 @@
 #include "dateedittest.h"
 #include <qdateeditex.h>
-#include <QVBoxLayout>
+#include <QFormLayout>
 #include <QLineEdit>
 
 DateEditTest::DateEditTest(QWidget *parent) :
-    QMainWindow(parent)
+    QWidget(parent)
 {
-    QWidget *wid = new QWidget;
-    QVBoxLayout *layout = new QVBoxLayout(wid);
-    QDateEditEx *edit = new QDateEditEx(wid);
+    QFormLayout *layout = new QFormLayout(this);
+    QDateEditEx *edit = new QDateEditEx(this);
     edit->setCalendarPopup(true);
     edit->setNullable(true);
-    layout->addWidget(edit);
-    edit = new QDateEditEx(wid);
+    edit->setDate(QDate(2014, 12, 31));
+    layout->addRow("Nullable date edit widget", edit);
+
+    edit = new QDateEditEx(this);
     edit->setCalendarPopup(true);
-    layout->addWidget(edit);
-    QLineEdit *ledit = new QLineEdit(wid);
-    layout->addWidget(ledit);
-
-    wid->setLayout(layout);
-
-
-    setCentralWidget(wid);
+    edit->setDate(QDate::currentDate());
+    layout->addRow("Date edit widget", edit);
 }
 
 DateEditTest::~DateEditTest()

--- a/test/dateedittest.h
+++ b/test/dateedittest.h
@@ -1,9 +1,9 @@
 #ifndef DATEEDITTEST_H
 #define DATEEDITTEST_H
 
-#include <QMainWindow>
+#include <QWidget>
 
-class DateEditTest : public QMainWindow
+class DateEditTest : public QWidget
 {
     Q_OBJECT
 

--- a/widgets/qdateeditex.cpp
+++ b/widgets/qdateeditex.cpp
@@ -172,6 +172,7 @@ void QDateEditEx::setNullable(bool enable)
 #endif // defined(WIDGETS_LIBRARY)
         d->clearButton->setIcon(QIcon(":/images/edit-clear-locationbar-rtl.png"));
         d->clearButton->setFocusPolicy(Qt::NoFocus);
+        d->clearButton->setFixedSize(17, d->clearButton->sizeHint().height()-6);
         connect(d->clearButton,SIGNAL(clicked()),this,SLOT(clearButtonClicked()));
     } else if (d->clearButton) {
         disconnect(d->clearButton,SIGNAL(clicked()),this,SLOT(clearButtonClicked()));
@@ -185,16 +186,37 @@ void QDateEditEx::setNullable(bool enable)
 /*!
   \reimp
 */
+QSize QDateEditEx::sizeHint() const
+{
+    const QSize sz = QDateEdit::sizeHint();
+    if (!d->clearButton)
+        return sz;
+    return QSize(sz.width() + d->clearButton->width() + 3, sz.height());
+}
+
+/*!
+  \reimp
+*/
+QSize QDateEditEx::minimumSizeHint() const
+{
+    const QSize sz = QDateEdit::minimumSizeHint();
+    if (!d->clearButton)
+        return sz;
+    return QSize(sz.width() + d->clearButton->width() + 3, sz.height());
+}
+
+/*!
+  \reimp
+*/
 void QDateEditEx::resizeEvent(QResizeEvent *event)
 {
     if (d->clearButton) {
-        d->clearButton->resize(17,d->clearButton->sizeHint().height()-6);
         QStyleOptionSpinBox opt;
         initStyleOption(&opt);
         opt.subControls = QStyle::SC_SpinBoxUp;
 
-        int left = style()->subControlRect(QStyle::CC_SpinBox, &opt, QStyle::SC_SpinBoxUp, this).width() + d->clearButton->width() + 3;
-        d->clearButton->move(size().width() - left,(size().height() - d->clearButton->height() )/2 );
+        int left = style()->subControlRect(QStyle::CC_SpinBox, &opt, QStyle::SC_SpinBoxUp, this).left() - d->clearButton->width() - 3;
+        d->clearButton->move(left, (height() - d->clearButton->height()) / 2);
     }
 
     QDateEdit::resizeEvent(event);

--- a/widgets/qdateeditex.h
+++ b/widgets/qdateeditex.h
@@ -41,6 +41,9 @@ public:
     bool isNullable() const;
     void setNullable(bool enable);
 
+    QSize sizeHint() const;
+    QSize minimumSizeHint() const;
+
 protected:
     /*! \reimp */ void resizeEvent(QResizeEvent *event);
     /*! \reimp */ void paintEvent(QPaintEvent *event);


### PR DESCRIPTION
Adjusted the test program to show the issue.

Fixed the positioning of the clear button to work better with styles that
have some space on the right of the "up" button, the old calculation assumed
there wasn't any, so the clear button could end up too much on the right,
almost over the arrow-down button.