### PR TITLE
Two fixes for QDateEditEx (minimumSizeHint() and dateChanged() signals)

### DIFF
--- a/test/dateedittest.cpp
+++ b/test/dateedittest.cpp
@@ -1,27 +1,22 @@
 #include "dateedittest.h"
 #include <qdateeditex.h>
-#include <QVBoxLayout>
+#include <QFormLayout>
 #include <QLineEdit>
 
 DateEditTest::DateEditTest(QWidget *parent) :
-    QMainWindow(parent)
+    QWidget(parent)
 {
-    QWidget *wid = new QWidget;
-    QVBoxLayout *layout = new QVBoxLayout(wid);
-    QDateEditEx *edit = new QDateEditEx(wid);
+    QFormLayout *layout = new QFormLayout(this);
+    QDateEditEx *edit = new QDateEditEx(this);
     edit->setCalendarPopup(true);
     edit->setNullable(true);
-    layout->addWidget(edit);
-    edit = new QDateEditEx(wid);
+    edit->setDate(QDate(2014, 12, 31));
+    layout->addRow("Nullable date edit widget", edit);
+
+    edit = new QDateEditEx(this);
     edit->setCalendarPopup(true);
-    layout->addWidget(edit);
-    QLineEdit *ledit = new QLineEdit(wid);
-    layout->addWidget(ledit);
-
-    wid->setLayout(layout);
-
-
-    setCentralWidget(wid);
+    edit->setDate(QDate::currentDate());
+    layout->addRow("Date edit widget", edit);
 }
 
 DateEditTest::~DateEditTest()

--- a/test/dateedittest.h
+++ b/test/dateedittest.h
@@ -1,9 +1,9 @@
 #ifndef DATEEDITTEST_H
 #define DATEEDITTEST_H
 
-#include <QMainWindow>
+#include <QWidget>
 
-class DateEditTest : public QMainWindow
+class DateEditTest : public QWidget
 {
     Q_OBJECT
 

--- a/widgets/qdateeditex.cpp
+++ b/widgets/qdateeditex.cpp
@@ -220,6 +220,12 @@ QSize QDateEditEx::minimumSizeHint() const
     return QSize(sz.width() + d->clearButton->width() + 3, sz.height());
 }
 
+void QDateEditEx::showEvent(QShowEvent *event)
+{
+    QDateEdit::showEvent(event);
+    d->setNull(d->null); // force empty string back in
+}
+
 /*!
   \reimp
 */

--- a/widgets/qdateeditex.cpp
+++ b/widgets/qdateeditex.cpp
@@ -53,13 +53,27 @@ public:
 
     bool null;
     bool nullable;
+
+    void setNull(bool n) {
+        null = n;
+        if (null) {
+            QLineEdit *edit = qFindChild<QLineEdit *>(q, "qt_spinbox_lineedit");
+            if (!edit->text().isEmpty()) {
+                edit->clear();
+            }
+        }
+        if (nullable) {
+            clearButton->setVisible(!null);
+        }
+
+    }
 };
 
 /*!
   \reimp
 */
 QDateEditEx::QDateEditEx(QWidget *parent) :
-    QDateEdit(parent),d( new Private(this))
+    QDateEdit(parent), d(new Private(this))
 {
 }
 
@@ -109,9 +123,9 @@ QTime QDateEditEx::time() const
 void QDateEditEx::setDateTime(const QDateTime &dateTime)
 {
     if (d->nullable && !dateTime.isValid()) {
-        d->null = true;
+        d->setNull(true);
     } else {
-        d->null = false;
+        d->setNull(false);
         QDateEdit::setDateTime(dateTime);
     }
 }
@@ -123,9 +137,9 @@ void QDateEditEx::setDateTime(const QDateTime &dateTime)
 void QDateEditEx::setDate(const QDate &date)
 {
     if (d->nullable && !date.isValid()) {
-        d->null = true;
+        d->setNull(true);
     } else {
-        d->null = false;
+        d->setNull(false);
         QDateEdit::setDate(date);
     }
 }
@@ -137,9 +151,9 @@ void QDateEditEx::setDate(const QDate &date)
 void QDateEditEx::setTime(const QTime &time)
 {
     if (d->nullable && !time.isValid()) {
-        d->null = true;
+        d->setNull(true);
     } else {
-        d->null = false;
+        d->setNull(false);
         QDateEdit::setTime(time);
     }
 }
@@ -174,6 +188,7 @@ void QDateEditEx::setNullable(bool enable)
         d->clearButton->setFocusPolicy(Qt::NoFocus);
         d->clearButton->setFixedSize(17, d->clearButton->sizeHint().height()-6);
         connect(d->clearButton,SIGNAL(clicked()),this,SLOT(clearButtonClicked()));
+        d->clearButton->setVisible(!d->null);
     } else if (d->clearButton) {
         disconnect(d->clearButton,SIGNAL(clicked()),this,SLOT(clearButtonClicked()));
         delete d->clearButton;
@@ -227,14 +242,6 @@ void QDateEditEx::resizeEvent(QResizeEvent *event)
 */
 void QDateEditEx::paintEvent(QPaintEvent *event)
 {
-    if (d->nullable && d->null) {
-        QLineEdit *edit = qFindChild<QLineEdit *>(this, "qt_spinbox_lineedit");
-        edit->setText("");
-
-        d->clearButton->setVisible(false);
-    } else if (d->nullable) {
-        d->clearButton->setVisible(true);
-    }
     QDateEdit::paintEvent(event);
 }
 
@@ -289,7 +296,15 @@ bool QDateEditEx::focusNextPrevChild(bool next)
     }
 }
 
+QValidator::State QDateEditEx::validate(QString &input, int &pos) const
+{
+    if (d->nullable && d->null){
+        return QValidator::Acceptable;
+    }
+    return QDateEdit::validate(input, pos);
+}
+
 void QDateEditEx::clearButtonClicked()
 {
-    d->null = true;
+    d->setNull(true);
 }

--- a/widgets/qdateeditex.cpp
+++ b/widgets/qdateeditex.cpp
@@ -172,6 +172,7 @@ void QDateEditEx::setNullable(bool enable)
 #endif // defined(WIDGETS_LIBRARY)
         d->clearButton->setIcon(QIcon(":/images/edit-clear-locationbar-rtl.png"));
         d->clearButton->setFocusPolicy(Qt::NoFocus);
+        d->clearButton->setFixedSize(17, d->clearButton->sizeHint().height()-6);
         connect(d->clearButton,SIGNAL(clicked()),this,SLOT(clearButtonClicked()));
     } else if (d->clearButton) {
         disconnect(d->clearButton,SIGNAL(clicked()),this,SLOT(clearButtonClicked()));
@@ -185,16 +186,37 @@ void QDateEditEx::setNullable(bool enable)
 /*!
   \reimp
 */
+QSize QDateEditEx::sizeHint() const
+{
+    const QSize sz = QDateEdit::sizeHint();
+    if (!d->clearButton)
+        return sz;
+    return QSize(sz.width() + d->clearButton->width() + 3, sz.height());
+}
+
+/*!
+  \reimp
+*/
+QSize QDateEditEx::minimumSizeHint() const
+{
+    const QSize sz = QDateEdit::minimumSizeHint();
+    if (!d->clearButton)
+        return sz;
+    return QSize(sz.width() + d->clearButton->width() + 3, sz.height());
+}
+
+/*!
+  \reimp
+*/
 void QDateEditEx::resizeEvent(QResizeEvent *event)
 {
     if (d->clearButton) {
-        d->clearButton->resize(17,d->clearButton->sizeHint().height()-6);
         QStyleOptionSpinBox opt;
         initStyleOption(&opt);
         opt.subControls = QStyle::SC_SpinBoxUp;
 
-        int left = style()->subControlRect(QStyle::CC_SpinBox, &opt, QStyle::SC_SpinBoxUp, this).width() + d->clearButton->width() + 3;
-        d->clearButton->move(size().width() - left,(size().height() - d->clearButton->height() )/2 );
+        int left = style()->subControlRect(QStyle::CC_SpinBox, &opt, QStyle::SC_SpinBoxUp, this).left() - d->clearButton->width() - 3;
+        d->clearButton->move(left, (height() - d->clearButton->height()) / 2);
     }
 
     QDateEdit::resizeEvent(event);

--- a/widgets/qdateeditex.h
+++ b/widgets/qdateeditex.h
@@ -41,6 +41,9 @@ public:
     bool isNullable() const;
     void setNullable(bool enable);
 
+    QSize sizeHint() const;
+    QSize minimumSizeHint() const;
+
 protected:
     /*! \reimp */ void resizeEvent(QResizeEvent *event);
     /*! \reimp */ void paintEvent(QPaintEvent *event);

--- a/widgets/qdateeditex.h
+++ b/widgets/qdateeditex.h
@@ -50,6 +50,7 @@ protected:
     /*! \reimp */ void keyPressEvent(QKeyEvent *event);
     /*! \reimp */ void mousePressEvent(QMouseEvent *event);
     /*! \reimp */ bool focusNextPrevChild(bool next);
+    /*! \reimp */ QValidator::State validate(QString &input, int &pos) const;
 
 public Q_SLOTS:
     /*! \reimp */ void setDateTime(const QDateTime &dateTime);

--- a/widgets/qdateeditex.h
+++ b/widgets/qdateeditex.h
@@ -45,6 +45,7 @@ public:
     QSize minimumSizeHint() const;
 
 protected:
+    /*! \reimp */ void showEvent(QShowEvent *event);
     /*! \reimp */ void resizeEvent(QResizeEvent *event);
     /*! \reimp */ void paintEvent(QPaintEvent *event);
     /*! \reimp */ void keyPressEvent(QKeyEvent *event);


### PR DESCRIPTION
Two commits:

1) Fix minimumSizeHint()
2) Fix spurious dateChanged() signals by using a more stable way of clearing the lineedit
